### PR TITLE
Fix outdated links for UniswapV2Router documentation

### DIFF
--- a/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
+++ b/src/content/developers/tutorials/uniswap-v2-annotated-code/index.md
@@ -1042,14 +1042,14 @@ for anybody else. Those are in the periphery so they can be updated as needed.
 ### UniswapV2Router01.sol {#UniswapV2Router01}
 
 [This contract](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router01.sol)
-has problems, and [should no longer be used](https://uniswap.org/docs/v2/smart-contracts/router01/). Luckily,
+has problems, and [should no longer be used](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-01/). Luckily,
 the periphery contracts are stateless and don't hold any assets, so it is easy to deprecate it and suggest
 people use the replacement, `UniswapV2Router02`, instead.
 
 ### UniswapV2Router02.sol {#UniswapV2Router02}
 
 In most cases you would use Uniswap through [this contract](https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/UniswapV2Router02.sol).
-You can see how to use it [here](https://uniswap.org/docs/v2/smart-contracts/router02/).
+You can see how to use it [here](https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-02/).
 
 ```solidity
 pragma solidity =0.6.6;


### PR DESCRIPTION
## Description
The links for UniswapV2Router docs were outdated and redirected into 404 pages
<img width="1097" alt="Screen Shot 2022-05-02 at 01 34 53" src="https://user-images.githubusercontent.com/12984659/166157623-56c5ee83-386c-4eb5-8873-0fd86782dbb3.png">


This PR is to ddd the updated links for UniswapV2Router docs
<img width="1093" alt="Screen Shot 2022-05-02 at 01 35 04" src="https://user-images.githubusercontent.com/12984659/166157638-060b2ef0-54cc-4d9b-bfa1-59c7787d5460.png">
